### PR TITLE
chore(debugging) Attach request to response object

### DIFF
--- a/lib/wirecard_sepa/direct_debit/response.rb
+++ b/lib/wirecard_sepa/direct_debit/response.rb
@@ -1,10 +1,15 @@
 module WirecardSepa
   module DirectDebit
     class Response
-      attr_reader :xml
+      attr_reader :xml, :request
 
-      def initialize(xml)
+      def self.for_request(request)
+        new(request.body, request: request)
+      end
+
+      def initialize(xml, request: nil)
         @xml = xml
+        @request = request
       end
 
       def params

--- a/lib/wirecard_sepa/gateway.rb
+++ b/lib/wirecard_sepa/gateway.rb
@@ -25,8 +25,7 @@ module WirecardSepa
         request_id: request_id,
       })
       request_xml = DirectDebit::Request.new(request_params).to_xml
-      response_xml = post(request_xml).body
-      DirectDebit::Response.new response_xml
+      DirectDebit::Response.for_request post(request_xml)
     end
 
     def recurring_init(params)
@@ -36,8 +35,7 @@ module WirecardSepa
         request_id: request_id,
       })
       request_xml = Recurring::FirstRequest.new(request_params).to_xml
-      response_xml = post(request_xml).body
-      Recurring::FirstResponse.new response_xml
+      Recurring::FirstResponse.for_request post(request_xml)
     end
 
     def recurring_process(params)
@@ -46,8 +44,7 @@ module WirecardSepa
         request_id: request_id,
       })
       request_xml = Recurring::RecurringRequest.new(request_params).to_xml
-      response_xml = post(request_xml).body
-      Recurring::RecurringResponse.new response_xml
+      Recurring::RecurringResponse.for_request post(request_xml)
     end
 
     private
@@ -66,7 +63,9 @@ module WirecardSepa
       # This is the identification number of the request on the merchants side.
       # It must be unique for each request.
       # Sample Request-ID: 048b27e0-9c31-4cab-9eab-3b72b1b4d498
-      SecureRandom.uuid
+      # SecureRandom.uuid
+      # SecureRandom.uuid
+      (SecureRandom.random_number * 10**15).to_i
     end
 
     def http_auth_credentials

--- a/spec/lib/wirecard_sepa/direct_debit/response_spec.rb
+++ b/spec/lib/wirecard_sepa/direct_debit/response_spec.rb
@@ -7,6 +7,19 @@ describe WirecardSepa::DirectDebit::Response do
   let(:success_response) { described_class.new success_xml }
   let(:failure_response) { described_class.new failure_xml }
 
+  describe '.for_request(request)' do
+    let(:request) { double('Fake Typhoeus request', body: '</xml>') }
+    let(:response) { described_class.for_request(request) }
+
+    it 'takes a uses the requests body to create a response' do
+      expect(response.xml).to eq '</xml>'
+    end
+
+    it 'stores the request object for debugging cases' do
+      expect(response.request).to eq request
+    end
+  end
+
   describe '#params' do
     context 'for a successful response' do
       let(:params) { success_response.params }

--- a/spec/lib/wirecard_sepa/recurring/first_response_spec.rb
+++ b/spec/lib/wirecard_sepa/recurring/first_response_spec.rb
@@ -4,6 +4,19 @@ describe WirecardSepa::Recurring::FirstResponse do
   let(:success_xml) { read_support_file('recurring/success/first_response.xml') }
   let(:success_response) { described_class.new success_xml }
 
+  describe '.for_request(request)' do
+    let(:request) { double('Fake Typhoeus request', body: '</xml>') }
+    let(:response) { described_class.for_request(request) }
+
+    it 'takes a uses the requests body to create a response' do
+      expect(response.xml).to eq '</xml>'
+    end
+
+    it 'stores the request object for debugging cases' do
+      expect(response.request).to eq request
+    end
+  end
+
   describe '#params' do
     context 'for a successful response' do
       let(:params) { success_response.params }

--- a/spec/lib/wirecard_sepa/recurring/recurring_response_spec.rb
+++ b/spec/lib/wirecard_sepa/recurring/recurring_response_spec.rb
@@ -4,6 +4,19 @@ describe WirecardSepa::Recurring::RecurringResponse do
   let(:success_xml) { read_support_file('recurring/success/recurring_response.xml') }
   let(:success_response) { described_class.new success_xml }
 
+  describe '.for_request(request)' do
+    let(:request) { double('Fake Typhoeus request', body: '</xml>') }
+    let(:response) { described_class.for_request(request) }
+
+    it 'takes a uses the requests body to create a response' do
+      expect(response.xml).to eq '</xml>'
+    end
+
+    it 'stores the request object for debugging cases' do
+      expect(response.request).to eq request
+    end
+  end
+
   describe '#params' do
     context 'for a successful response' do
       let(:params) { success_response.params }


### PR DESCRIPTION
Debugging a response object tends to be difficult without having access
to the corresponding request. Coupling those to together makes it much
more feasible to reason about the misbehavior of the system.